### PR TITLE
Add auto-injected QMS header to all documentation pages

### DIFF
--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -22,7 +22,7 @@ def normalize_author_name(name: str) -> str:
     return AUTHOR_NAME_MAP.get(name, name)
 
 
-def create_header(document_reference, git_commit_datetime, git_sha, last_author):
+def create_header(document_reference, author_datetime, commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
     # Create a collapsible details element
     details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
@@ -36,8 +36,11 @@ def create_header(document_reference, git_commit_datetime, git_sha, last_author)
     # Last Edited By
     header_list += create_item("Last Edited By", last_author)
 
-    # Effective from (when this version became active)
-    header_list += create_item("Effective from", git_commit_datetime)
+    # Last Edited (author date - when changes were made)
+    header_list += create_item("Last Edited", author_datetime)
+
+    # Effective from (commit date - when this version was approved/merged)
+    header_list += create_item("Effective from", commit_datetime)
 
     # Git Commit with link to commit on GitHub
     commit_link = nodes.reference(refuri=f"{gh_repo_url}/commit/{git_sha}")
@@ -109,26 +112,28 @@ def get_git_info_for_file(path):
     # this file, if the file is changed but not committed, this will not
     # be reflected in the header.
     try:
-        # Single git call with combined format: sha|author_date|author_name
+        # Single git call with combined format: sha|author_date|commit_date|author_name
+        # Author date (%aI) = when the author made the changes
+        # Commit date (%cI) = when the commit was applied (e.g., merged/rebased)
         git_output = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%h|%aI|%aN", "--", relative_path
+            "git", "log", "-n", "1", "--format=%h|%aI|%cI|%aN", "--", relative_path
         ], text=True, stderr=subprocess.STDOUT).strip()
 
         # Handle case where file has no git history (empty output)
         if not git_output:
-            return "unknown", None, "unknown"
+            return "unknown", None, None, "unknown"
 
         parts = git_output.split("|")
-        if len(parts) != 3:
-            return "unknown", None, "unknown"
+        if len(parts) != 4:
+            return "unknown", None, None, "unknown"
 
-        git_sha, author_date, author_name = parts
+        git_sha, author_date, commit_date, author_name = parts
         # Normalize the author name for consistent display
         author_name = normalize_author_name(author_name)
 
-        return git_sha, author_date, author_name
+        return git_sha, author_date, commit_date, author_name
     except subprocess.CalledProcessError:
-        return "unknown", None, "unknown"
+        return "unknown", None, None, "unknown"
 
 
 def add_qms_header_to_doctree(app, doctree, docname):
@@ -136,22 +141,31 @@ def add_qms_header_to_doctree(app, doctree, docname):
     # Get the source file path
     source_path = app.env.doc2path(docname)
 
-    git_sha, author_date, author_name = get_git_info_for_file(source_path)
+    git_sha, author_date, commit_date, author_name = get_git_info_for_file(source_path)
 
     # Document reference is the docname path with source file extension
     # e.g., "about/index.rst" or "documentation/guide.md"
     source_file = pathlib.Path(source_path)
     document_reference = f"{docname}{source_file.suffix}"
 
+    # Format author date (when changes were made)
     if author_date:
-        parsed_date = dateutil.parser.isoparse(author_date)
-        git_commit_datetime = format_datetime(parsed_date)
+        parsed_author_date = dateutil.parser.isoparse(author_date)
+        author_datetime = format_datetime(parsed_author_date)
     else:
-        git_commit_datetime = "unknown"
+        author_datetime = "unknown"
+
+    # Format commit date (when changes were approved/merged)
+    if commit_date:
+        parsed_commit_date = dateutil.parser.isoparse(commit_date)
+        commit_datetime = format_datetime(parsed_commit_date)
+    else:
+        commit_datetime = "unknown"
 
     header = create_header(
         document_reference,
-        git_commit_datetime,
+        author_datetime,
+        commit_datetime,
         git_sha,
         author_name
     )
@@ -165,7 +179,7 @@ def setup(app):
     app.connect('doctree-resolved', add_qms_header_to_doctree)
 
     return {
-        'version': '0.3',
+        'version': '0.4',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -10,7 +10,7 @@ import os
 gh_repo_url = "https://github.com/Better-Conversations/betterconversations.foundation"
 
 
-def create_header(document_reference, date, git_sha, git_commit_datetime, last_author):
+def create_header(document_reference, git_commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
     # Create a collapsible details element
     details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
@@ -20,18 +20,17 @@ def create_header(document_reference, date, git_sha, git_commit_datetime, last_a
 
     # Document reference
     header_list += create_item("Reference", document_reference)
-    header_list += create_item("Last Changed Date", date)
 
-    # Git Commit Date with link to commit on GitHub and timestamp
-    commit_para = nodes.paragraph()
+    # Last Edited By (moved to second position)
+    header_list += create_item("Last Edited By", last_author)
+
+    # Last Edited Date with full date/time stamp
+    header_list += create_item("Last Edited Date", git_commit_datetime)
+
+    # Git Commit with link to commit on GitHub
     commit_link = nodes.reference(refuri=f"{gh_repo_url}/commit/{git_sha}")
     commit_link += nodes.Text(git_sha)
-    commit_para += commit_link
-    commit_para += nodes.Text(f" ({git_commit_datetime})")
-    header_list += create_item("Git Commit Date", commit_para)
-
-    # Last Edited By
-    header_list += create_item("Last Edited By", last_author)
+    header_list += create_item("Git Commit", commit_link)
 
     # Only valid online - create a paragraph with mixed text and link
     note_para = nodes.paragraph()
@@ -69,17 +68,6 @@ def create_item(label, value: str | nodes.Node):
 
     item += para
     return item
-
-
-def format_date(date: datetime) -> str:
-    """Format date as '23rd January 2026'."""
-    day = date.day
-    if 11 <= day <= 13:
-        suffix = 'th'
-    else:
-        suffix = ['th', 'st', 'nd', 'rd', 'th'][min(day % 10, 4)]
-
-    return f"{day}{suffix} {date.strftime('%B %Y')}"
 
 
 def format_datetime(date: datetime) -> str:
@@ -143,17 +131,14 @@ class QMSHeader(Directive):
 
         if last_updated_date:
             parsed_date = dateutil.parser.isoparse(last_updated_date)
-            formatted_date = format_date(parsed_date)
             git_commit_datetime = format_datetime(parsed_date)
         else:
-            formatted_date = "unknown"
             git_commit_datetime = "unknown"
 
         return [create_header(
             document_reference,
-            formatted_date,
-            git_sha,
             git_commit_datetime,
+            git_sha,
             last_author
         )]
 
@@ -168,17 +153,14 @@ def add_qms_header_to_doctree(app, doctree, docname):
 
     if last_updated_date:
         parsed_date = dateutil.parser.isoparse(last_updated_date)
-        formatted_date = format_date(parsed_date)
         git_commit_datetime = format_datetime(parsed_date)
     else:
-        formatted_date = "unknown"
         git_commit_datetime = "unknown"
 
     header = create_header(
         document_reference,
-        formatted_date,
-        git_sha,
         git_commit_datetime,
+        git_sha,
         last_author
     )
 

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -7,7 +7,7 @@ from docutils.parsers.rst import Directive
 from docutils import nodes
 import os
 
-gh_repo_url = "https://github.com/Better-Conversations/betterconversations.foundation"
+gh_repo_url = "https://github.com/Better-Conversations/docs.bettercourses.org"
 
 # Mapping of git author names/usernames to consistent display names
 AUTHOR_NAME_MAP = {

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -14,7 +14,7 @@ AUTHOR_NAME_MAP = {
     "chandima-d": "Chandima Dutton",
     "chandimad": "Chandima Dutton",
     "alexjcoles": "Alex Coles",
-    "shivamphora": "Shivam Phora",
+    "shivamphora": "Shivani Patel",
 }
 
 

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -10,25 +10,45 @@ import os
 gh_repo_url = "https://github.com/Better-Conversations/betterconversations.foundation"
 
 
-def create_header(document_reference, date, git_sha, last_author):
+def create_header(document_reference, date, git_sha, git_commit_datetime, last_author):
+    """Create the QMS header as a collapsible details element."""
+    # Create a collapsible details element
+    details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
+    details_close = nodes.raw('', '</details>', format='html')
+
     header_list = nodes.bullet_list()
 
     # Document reference
     header_list += create_item("Reference", document_reference)
     header_list += create_item("Last Changed Date", date)
 
-    # Revision (in form of git sha) with link to commit on GitHub
-    rev_link = nodes.reference(refuri=f"{gh_repo_url}/commit/{git_sha}")
-    rev_link += nodes.Text(git_sha)
-    header_list += create_item("Git Version", rev_link)
+    # Git Commit Date with link to commit on GitHub and timestamp
+    commit_para = nodes.paragraph()
+    commit_link = nodes.reference(refuri=f"{gh_repo_url}/commit/{git_sha}")
+    commit_link += nodes.Text(git_sha)
+    commit_para += commit_link
+    commit_para += nodes.Text(f" ({git_commit_datetime})")
+    header_list += create_item("Git Commit Date", commit_para)
 
-    # Approved by
+    # Last Edited By
     header_list += create_item("Last Edited By", last_author)
 
-    # Only valid online
-    header_list += create_item("Note", "Document is only valid online at https://betterconversations.foundation.")
+    # Only valid online - create a paragraph with mixed text and link
+    note_para = nodes.paragraph()
+    note_para += nodes.Text("Please refer to ")
+    docs_link = nodes.reference(refuri="https://docs.bettercourses.org")
+    docs_link += nodes.Text("docs.bettercourses.org")
+    note_para += docs_link
+    note_para += nodes.Text(" for valid technical documentation. Printed or downloaded copies may not reflect the current BCF documentation.")
+    header_list += create_item("Note", note_para)
 
-    return header_list
+    # Return wrapped in details element
+    container = nodes.container()
+    container += details_open
+    container += header_list
+    container += details_close
+
+    return container
 
 
 def create_item(label, value: str | nodes.Node):
@@ -38,116 +58,143 @@ def create_item(label, value: str | nodes.Node):
     item = nodes.list_item()
     para = nodes.paragraph()
     strong = nodes.strong(text=f"{label}: ")
-    text = value
     para += strong
-    para += text
+
+    # If value is a paragraph, extract its children to avoid nested paragraphs
+    if isinstance(value, nodes.paragraph):
+        for child in value.children:
+            para += child
+    else:
+        para += value
+
     item += para
     return item
 
 
 def format_date(date: datetime) -> str:
-    # Get the day with the appropriate suffix (e.g., 1st, 2nd, 3rd, 4th)
+    """Format date as '23rd January 2026'."""
     day = date.day
     if 11 <= day <= 13:
         suffix = 'th'
     else:
         suffix = ['th', 'st', 'nd', 'rd', 'th'][min(day % 10, 4)]
 
-    # Format the date as desired
-    formatted_date = f"{day}{suffix} {date.strftime('%B %Y')}"
+    return f"{day}{suffix} {date.strftime('%B %Y')}"
 
-    return formatted_date
+
+def format_datetime(date: datetime) -> str:
+    """Format datetime as '23rd January 2026 at 13:14'."""
+    day = date.day
+    if 11 <= day <= 13:
+        suffix = 'th'
+    else:
+        suffix = ['th', 'st', 'nd', 'rd', 'th'][min(day % 10, 4)]
+
+    return f"{day}{suffix} {date.strftime('%B %Y')} at {date.strftime('%H:%M')}"
+
+
+def get_git_info_for_file(path):
+    """Get git information for a specific file."""
+    # Convert absolute path to relative path within the repository
+    try:
+        repo_path = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            text=True
+        ).strip()
+        relative_path = os.path.relpath(path, repo_path) if os.path.isabs(path) else path
+    except (subprocess.SubprocessError, FileNotFoundError):
+        relative_path = os.path.basename(path)
+
+    # Note that git information will be for the last commit that touched
+    # this file, if the file is changed but not committed, this will not
+    # be reflected in the header.
+    try:
+        last_relevant_git_sha = subprocess.check_output([
+            "git", "log", "-n", "1", "--format=%h", "--", relative_path
+        ], text=True, stderr=subprocess.STDOUT).strip()
+
+        last_updated_date = subprocess.check_output([
+            "git", "log", "-n", "1", "--format=%cI", "--", relative_path
+        ], text=True, stderr=subprocess.STDOUT).strip()
+
+        last_author = subprocess.check_output([
+            "git", "log", "-n", "1", "--format=%cN", "--", relative_path
+        ], text=True, stderr=subprocess.STDOUT).strip()
+
+        # Handle case where file has no git history (empty output)
+        if not last_relevant_git_sha or not last_updated_date:
+            last_relevant_git_sha = "unknown"
+            last_updated_date = None
+            last_author = "unknown"
+    except subprocess.CalledProcessError:
+        last_relevant_git_sha = "unknown"
+        last_updated_date = None
+        last_author = "unknown"
+
+    return last_relevant_git_sha, last_updated_date, last_author
 
 
 class QMSHeader(Directive):
+    """Directive for manually inserting QMS header (kept for backwards compatibility)."""
     def run(self):
         path = self.state.document.current_source
-        # print(f"QMSHeader Debug: Initial path = {path}") # Debug print
+        git_sha, last_updated_date, last_author = get_git_info_for_file(path)
+        document_reference = pathlib.Path(path).stem
 
-        # Convert absolute path to relative path within the repository
-        # This is needed for GitHub Actions where paths include the full workspace path
-        try:
-            # First try to make the path relative to the current working directory
-            # print("QMSHeader Debug: Running 'git rev-parse --show-toplevel'") # Debug print
-            repo_path = subprocess.check_output(["git", "rev-parse", "--show-toplevel"], text=True).strip()
-            # print(f"QMSHeader Debug: repo_path = {repo_path}") # Debug print
-            relative_path = os.path.relpath(path, repo_path) if os.path.isabs(path) else path
-            # print(f"QMSHeader Debug: Calculated relative_path = {relative_path}") # Debug print
-        except (subprocess.SubprocessError, FileNotFoundError) as e:
-            # print(f"QMSHeader Debug: Error getting repo path: {e}") # Debug print
-            # If that fails, just use the filename which might work in simple cases
-            relative_path = os.path.basename(path)
-            # print(f"QMSHeader Debug: Fallback relative_path = {relative_path}") # Debug print
-
-        # Note that git information will be for the last commit that touched
-        # this file, if the file is changed but not committed, this will not
-        # be reflected in the header.
-
-        try:
-            # Get latest commit sha for this file
-            # print(f"QMSHeader Debug: Running git log for sha on {relative_path}") # Debug print
-            last_relevant_git_sha = subprocess.check_output([
-                "git",
-                "log",
-                "-n", "1",
-                "--format=%h",
-                "--",
-                relative_path
-            ], text=True, stderr=subprocess.STDOUT).strip() # Capture stderr
-            # print(f"QMSHeader Debug: last_relevant_git_sha = {last_relevant_git_sha}") # Debug print
-
-            # Get last updated date for this file
-            # print(f"QMSHeader Debug: Running git log for date on {relative_path}") # Debug print
-            last_updated_date = subprocess.check_output([
-                "git",
-                "log",
-                "-n", "1",
-                "--format=%cI",
-                "--",
-                relative_path
-            ], text=True, stderr=subprocess.STDOUT).strip() # Capture stderr
-            # print(f"QMSHeader Debug: last_updated_date = {last_updated_date}") # Debug print
-
-            # Get last author for this file, named by their git settings
-            # print(f"QMSHeader Debug: Running git log for author on {relative_path}") # Debug print
-            last_author = subprocess.check_output([
-                "git",
-                "log",
-                "-n", "1",
-                "--format=%cN",
-                "--",
-                relative_path
-            ], text=True, stderr=subprocess.STDOUT).strip() # Capture stderr
-            # print(f"QMSHeader Debug: last_author = {last_author}") # Debug print
-        except subprocess.CalledProcessError as e:
-            # print(f"QMSHeader Debug: Error running git log: {e}") # Debug print
-            # print(f"QMSHeader Debug: Command output: {e.output}") # Print command output on error
-            # Fallback if git commands fail
-            last_relevant_git_sha = "unknown"
-            last_updated_date = datetime.now().isoformat()
-            last_author = "unknown"
-
-        # Remove the file extension from the file name to get the document reference
-        document_reference = pathlib.Path(self.state.document.current_source).stem
-
-        if last_updated_date != "unknown":
-            formatted_date = format_date(dateutil.parser.isoparse(last_updated_date))
+        if last_updated_date:
+            parsed_date = dateutil.parser.isoparse(last_updated_date)
+            formatted_date = format_date(parsed_date)
+            git_commit_datetime = format_datetime(parsed_date)
         else:
             formatted_date = "unknown"
+            git_commit_datetime = "unknown"
 
         return [create_header(
             document_reference,
             formatted_date,
-            last_relevant_git_sha,
+            git_sha,
+            git_commit_datetime,
             last_author
         )]
 
 
+def add_qms_header_to_doctree(app, doctree, docname):
+    """Add QMS header to every page automatically during doctree-resolved."""
+    # Get the source file path
+    source_path = app.env.doc2path(docname)
+
+    git_sha, last_updated_date, last_author = get_git_info_for_file(source_path)
+    document_reference = pathlib.Path(source_path).stem
+
+    if last_updated_date:
+        parsed_date = dateutil.parser.isoparse(last_updated_date)
+        formatted_date = format_date(parsed_date)
+        git_commit_datetime = format_datetime(parsed_date)
+    else:
+        formatted_date = "unknown"
+        git_commit_datetime = "unknown"
+
+    header = create_header(
+        document_reference,
+        formatted_date,
+        git_sha,
+        git_commit_datetime,
+        last_author
+    )
+
+    # Append the header to the end of the document
+    doctree.append(header)
+
+
 def setup(app):
+    # Keep the directive for backwards compatibility
     app.add_directive('qms_header', QMSHeader)
 
+    # Auto-inject QMS header at the bottom of every page
+    app.connect('doctree-resolved', add_qms_header_to_doctree)
+
     return {
-        'version': '0.1',
+        'version': '0.2',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -101,12 +101,15 @@ def get_git_info_for_file(path):
             "git", "log", "-n", "1", "--format=%h", "--", relative_path
         ], text=True, stderr=subprocess.STDOUT).strip()
 
+        # Use author date (%aI) - when changes were originally written
+        # (not committer date which can differ with rebases/cherry-picks)
         last_updated_date = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%cI", "--", relative_path
+            "git", "log", "-n", "1", "--format=%aI", "--", relative_path
         ], text=True, stderr=subprocess.STDOUT).strip()
 
+        # Use author name (%aN) to match the author date
         last_author = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%cN", "--", relative_path
+            "git", "log", "-n", "1", "--format=%aN", "--", relative_path
         ], text=True, stderr=subprocess.STDOUT).strip()
 
         # Handle case where file has no git history (empty output)

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -86,14 +86,29 @@ def create_item(label, value: str | nodes.Node):
 
 
 def format_datetime(date: datetime) -> str:
-    """Format datetime as '23rd January 2026 at 13:14'."""
+    """Format datetime as '23rd January 2026 at 13:14 UTC'."""
     day = date.day
     if 11 <= day <= 13:
         suffix = 'th'
     else:
         suffix = ['th', 'st', 'nd', 'rd', 'th'][min(day % 10, 4)]
 
-    return f"{day}{suffix} {date.strftime('%B %Y')} at {date.strftime('%H:%M')}"
+    # Get timezone abbreviation if available, otherwise show UTC offset
+    if date.tzinfo:
+        tz_name = date.strftime('%Z')
+        if not tz_name:
+            # Fall back to UTC offset format if no name available
+            tz_name = date.strftime('%z')
+            # Format +0000 as UTC, otherwise show offset like +01:00
+            if tz_name == '+0000':
+                tz_name = 'UTC'
+            elif tz_name:
+                tz_name = f"{tz_name[:3]}:{tz_name[3:]}"
+    else:
+        tz_name = ''
+
+    tz_suffix = f" {tz_name}" if tz_name else ""
+    return f"{day}{suffix} {date.strftime('%B %Y')} at {date.strftime('%H:%M')}{tz_suffix}"
 
 
 def get_git_info_for_file(path):
@@ -183,7 +198,7 @@ def setup(app):
     app.connect('doctree-resolved', add_qms_header_to_doctree)
 
     return {
-        'version': '0.5',
+        'version': '0.6',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -9,6 +9,19 @@ import os
 
 gh_repo_url = "https://github.com/Better-Conversations/betterconversations.foundation"
 
+# Mapping of git author names/usernames to consistent display names
+AUTHOR_NAME_MAP = {
+    "chandima-d": "Chandima Dutton",
+    "chandimad": "Chandima Dutton",
+    "alexjcoles": "Alex Coles",
+    "shivamphora": "Shivam Phora",
+}
+
+
+def normalize_author_name(name: str) -> str:
+    """Normalize git author names to consistent display names."""
+    return AUTHOR_NAME_MAP.get(name, name)
+
 
 def create_header(document_reference, git_commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
@@ -117,6 +130,9 @@ def get_git_info_for_file(path):
             last_relevant_git_sha = "unknown"
             last_updated_date = None
             last_author = "unknown"
+        else:
+            # Normalize the author name for consistent display
+            last_author = normalize_author_name(last_author)
     except subprocess.CalledProcessError:
         last_relevant_git_sha = "unknown"
         last_updated_date = None

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -24,8 +24,8 @@ def normalize_author_name(name: str) -> str:
 
 def create_header(document_reference, author_datetime, commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
-    # Create a collapsible details element
-    details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
+    # Create a collapsible details element with accessibility attributes
+    details_open = nodes.raw('', '<details class="qms-header" role="group" aria-label="Document information"><summary aria-expanded="false">Document Information</summary>', format='html')
     details_close = nodes.raw('', '</details>', format='html')
 
     header_list = nodes.bullet_list()
@@ -183,7 +183,7 @@ def setup(app):
     app.connect('doctree-resolved', add_qms_header_to_doctree)
 
     return {
-        'version': '0.4',
+        'version': '0.5',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -133,6 +133,10 @@ def get_git_info_for_file(path):
 
 def add_qms_header_to_doctree(app, doctree, docname):
     """Add QMS header to every page automatically during doctree-resolved."""
+    # Only inject the header for HTML builds to avoid issues with PDF and other formats
+    if app.builder.format != 'html':
+        return
+    
     # Get the source file path
     source_path = app.env.doc2path(docname)
 

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -1,6 +1,5 @@
 import pathlib
 import subprocess
-import sys
 from datetime import datetime
 import dateutil
 from docutils.parsers.rst import Directive
@@ -8,6 +7,7 @@ from docutils import nodes
 import os
 
 gh_repo_url = "https://github.com/Better-Conversations/docs.bettercourses.org"
+docs_base_url = "https://docs.bettercourses.org"
 
 # Mapping of git author names/usernames to consistent display names
 AUTHOR_NAME_MAP = {
@@ -23,7 +23,7 @@ def normalize_author_name(name: str) -> str:
     return AUTHOR_NAME_MAP.get(name, name)
 
 
-def create_header(document_reference, git_commit_datetime, git_sha, last_author):
+def create_header(document_reference, document_url, git_commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
     # Create a collapsible details element
     details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
@@ -31,27 +31,29 @@ def create_header(document_reference, git_commit_datetime, git_sha, last_author)
 
     header_list = nodes.bullet_list()
 
-    # Document reference
-    header_list += create_item("Reference", document_reference)
+    # Document reference with link to the document URL
+    ref_link = nodes.reference(refuri=document_url)
+    ref_link += nodes.Text(document_reference)
+    header_list += create_item("Reference", ref_link)
 
-    # Last Edited By (moved to second position)
+    # Last Edited By
     header_list += create_item("Last Edited By", last_author)
 
-    # Last Edited Date with full date/time stamp
-    header_list += create_item("Last Edited Date", git_commit_datetime)
+    # Effective from (when this version became active)
+    header_list += create_item("Effective from", git_commit_datetime)
 
     # Git Commit with link to commit on GitHub
     commit_link = nodes.reference(refuri=f"{gh_repo_url}/commit/{git_sha}")
     commit_link += nodes.Text(git_sha)
     header_list += create_item("Git Commit", commit_link)
 
-    # Only valid online - create a paragraph with mixed text and link
+    # Document status note - deployed = approved
     note_para = nodes.paragraph()
-    note_para += nodes.Text("Please refer to ")
-    docs_link = nodes.reference(refuri="https://docs.bettercourses.org")
+    note_para += nodes.Text("This is the current approved version. Printed or downloaded copies may be superseded; refer to ")
+    docs_link = nodes.reference(refuri=docs_base_url)
     docs_link += nodes.Text("docs.bettercourses.org")
     note_para += docs_link
-    note_para += nodes.Text(" for valid technical documentation. Printed or downloaded copies may not reflect the current BCF documentation.")
+    note_para += nodes.Text(" for the authoritative version.")
     header_list += create_item("Note", note_para)
 
     # Return wrapped in details element
@@ -110,55 +112,54 @@ def get_git_info_for_file(path):
     # this file, if the file is changed but not committed, this will not
     # be reflected in the header.
     try:
-        last_relevant_git_sha = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%h", "--", relative_path
-        ], text=True, stderr=subprocess.STDOUT).strip()
-
-        # Use author date (%aI) - when changes were originally written
-        # (not committer date which can differ with rebases/cherry-picks)
-        last_updated_date = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%aI", "--", relative_path
-        ], text=True, stderr=subprocess.STDOUT).strip()
-
-        # Use author name (%aN) to match the author date
-        last_author = subprocess.check_output([
-            "git", "log", "-n", "1", "--format=%aN", "--", relative_path
+        # Single git call with combined format: sha|author_date|author_name
+        git_output = subprocess.check_output([
+            "git", "log", "-n", "1", "--format=%h|%aI|%aN", "--", relative_path
         ], text=True, stderr=subprocess.STDOUT).strip()
 
         # Handle case where file has no git history (empty output)
-        if not last_relevant_git_sha or not last_updated_date:
-            last_relevant_git_sha = "unknown"
-            last_updated_date = None
-            last_author = "unknown"
-        else:
-            # Normalize the author name for consistent display
-            last_author = normalize_author_name(last_author)
-    except subprocess.CalledProcessError:
-        last_relevant_git_sha = "unknown"
-        last_updated_date = None
-        last_author = "unknown"
+        if not git_output:
+            return "unknown", None, "unknown"
 
-    return last_relevant_git_sha, last_updated_date, last_author
+        parts = git_output.split("|")
+        if len(parts) != 3:
+            return "unknown", None, "unknown"
+
+        git_sha, author_date, author_name = parts
+        # Normalize the author name for consistent display
+        author_name = normalize_author_name(author_name)
+
+        return git_sha, author_date, author_name
+    except subprocess.CalledProcessError:
+        return "unknown", None, "unknown"
 
 
 class QMSHeader(Directive):
     """Directive for manually inserting QMS header (kept for backwards compatibility)."""
     def run(self):
         path = self.state.document.current_source
-        git_sha, last_updated_date, last_author = get_git_info_for_file(path)
-        document_reference = pathlib.Path(path).stem
+        git_sha, author_date, author_name = get_git_info_for_file(path)
 
-        if last_updated_date:
-            parsed_date = dateutil.parser.isoparse(last_updated_date)
+        # Get the relative path from source directory for the reference
+        source_path = pathlib.Path(path)
+        # Document reference is the relative path with extension
+        document_reference = source_path.name
+
+        # Build the document URL (docname would be better but not available here)
+        document_url = f"{docs_base_url}/{source_path.stem}.html"
+
+        if author_date:
+            parsed_date = dateutil.parser.isoparse(author_date)
             git_commit_datetime = format_datetime(parsed_date)
         else:
             git_commit_datetime = "unknown"
 
         return [create_header(
             document_reference,
+            document_url,
             git_commit_datetime,
             git_sha,
-            last_author
+            author_name
         )]
 
 
@@ -167,20 +168,26 @@ def add_qms_header_to_doctree(app, doctree, docname):
     # Get the source file path
     source_path = app.env.doc2path(docname)
 
-    git_sha, last_updated_date, last_author = get_git_info_for_file(source_path)
-    document_reference = pathlib.Path(source_path).stem
+    git_sha, author_date, author_name = get_git_info_for_file(source_path)
 
-    if last_updated_date:
-        parsed_date = dateutil.parser.isoparse(last_updated_date)
+    # Document reference is the source filename with extension
+    document_reference = pathlib.Path(source_path).name
+
+    # Build the full document URL from docname
+    document_url = f"{docs_base_url}/{docname}.html"
+
+    if author_date:
+        parsed_date = dateutil.parser.isoparse(author_date)
         git_commit_datetime = format_datetime(parsed_date)
     else:
         git_commit_datetime = "unknown"
 
     header = create_header(
         document_reference,
+        document_url,
         git_commit_datetime,
         git_sha,
-        last_author
+        author_name
     )
 
     # Append the header to the end of the document

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -7,7 +7,7 @@ from docutils import nodes
 import os
 
 gh_repo_url = "https://github.com/Better-Conversations/docs.bettercourses.org"
-docs_base_url = "https://docs.bettercourses.org"
+docs_site_url = "https://docs.bettercourses.org"
 
 # Mapping of git author names/usernames to consistent display names
 AUTHOR_NAME_MAP = {
@@ -23,7 +23,7 @@ def normalize_author_name(name: str) -> str:
     return AUTHOR_NAME_MAP.get(name, name)
 
 
-def create_header(document_reference, document_url, git_commit_datetime, git_sha, last_author):
+def create_header(document_reference, git_commit_datetime, git_sha, last_author):
     """Create the QMS header as a collapsible details element."""
     # Create a collapsible details element
     details_open = nodes.raw('', '<details class="qms-header"><summary>Document Information</summary>', format='html')
@@ -31,10 +31,8 @@ def create_header(document_reference, document_url, git_commit_datetime, git_sha
 
     header_list = nodes.bullet_list()
 
-    # Document reference with link to the document URL
-    ref_link = nodes.reference(refuri=document_url)
-    ref_link += nodes.Text(document_reference)
-    header_list += create_item("Reference", ref_link)
+    # Document reference (file path)
+    header_list += create_item("Reference", document_reference)
 
     # Last Edited By
     header_list += create_item("Last Edited By", last_author)
@@ -50,7 +48,7 @@ def create_header(document_reference, document_url, git_commit_datetime, git_sha
     # Document status note - deployed = approved
     note_para = nodes.paragraph()
     note_para += nodes.Text("This is the current approved version. Printed or downloaded copies may be superseded; refer to ")
-    docs_link = nodes.reference(refuri=docs_base_url)
+    docs_link = nodes.reference(refuri=docs_site_url)
     docs_link += nodes.Text("docs.bettercourses.org")
     note_para += docs_link
     note_para += nodes.Text(" for the authoritative version.")
@@ -140,13 +138,8 @@ class QMSHeader(Directive):
         path = self.state.document.current_source
         git_sha, author_date, author_name = get_git_info_for_file(path)
 
-        # Get the relative path from source directory for the reference
-        source_path = pathlib.Path(path)
-        # Document reference is the relative path with extension
-        document_reference = source_path.name
-
-        # Build the document URL (docname would be better but not available here)
-        document_url = f"{docs_base_url}/{source_path.stem}.html"
+        # Document reference is the filename with extension
+        document_reference = pathlib.Path(path).name
 
         if author_date:
             parsed_date = dateutil.parser.isoparse(author_date)
@@ -156,7 +149,6 @@ class QMSHeader(Directive):
 
         return [create_header(
             document_reference,
-            document_url,
             git_commit_datetime,
             git_sha,
             author_name
@@ -170,11 +162,10 @@ def add_qms_header_to_doctree(app, doctree, docname):
 
     git_sha, author_date, author_name = get_git_info_for_file(source_path)
 
-    # Document reference is the source filename with extension
-    document_reference = pathlib.Path(source_path).name
-
-    # Build the full document URL from docname
-    document_url = f"{docs_base_url}/{docname}.html"
+    # Document reference is the docname path with source file extension
+    # e.g., "about/index.rst" or "documentation/guide.md"
+    source_file = pathlib.Path(source_path)
+    document_reference = f"{docname}{source_file.suffix}"
 
     if author_date:
         parsed_date = dateutil.parser.isoparse(author_date)
@@ -184,7 +175,6 @@ def add_qms_header_to_doctree(app, doctree, docname):
 
     header = create_header(
         document_reference,
-        document_url,
         git_commit_datetime,
         git_sha,
         author_name

--- a/source/_ext/qms_header.py
+++ b/source/_ext/qms_header.py
@@ -2,7 +2,6 @@ import pathlib
 import subprocess
 from datetime import datetime
 import dateutil
-from docutils.parsers.rst import Directive
 from docutils import nodes
 import os
 
@@ -132,29 +131,6 @@ def get_git_info_for_file(path):
         return "unknown", None, "unknown"
 
 
-class QMSHeader(Directive):
-    """Directive for manually inserting QMS header (kept for backwards compatibility)."""
-    def run(self):
-        path = self.state.document.current_source
-        git_sha, author_date, author_name = get_git_info_for_file(path)
-
-        # Document reference is the filename with extension
-        document_reference = pathlib.Path(path).name
-
-        if author_date:
-            parsed_date = dateutil.parser.isoparse(author_date)
-            git_commit_datetime = format_datetime(parsed_date)
-        else:
-            git_commit_datetime = "unknown"
-
-        return [create_header(
-            document_reference,
-            git_commit_datetime,
-            git_sha,
-            author_name
-        )]
-
-
 def add_qms_header_to_doctree(app, doctree, docname):
     """Add QMS header to every page automatically during doctree-resolved."""
     # Get the source file path
@@ -185,14 +161,11 @@ def add_qms_header_to_doctree(app, doctree, docname):
 
 
 def setup(app):
-    # Keep the directive for backwards compatibility
-    app.add_directive('qms_header', QMSHeader)
-
     # Auto-inject QMS header at the bottom of every page
     app.connect('doctree-resolved', add_qms_header_to_doctree)
 
     return {
-        'version': '0.2',
+        'version': '0.3',
         'parallel_read_safe': True,
         'parallel_write_safe': True,
     }

--- a/source/_templates/utterances.html
+++ b/source/_templates/utterances.html
@@ -1,5 +1,5 @@
 <script src="https://utteranc.es/client.js"
-    repo="Better-Conversations/betterconversations.foundation"
+    repo="Better-Conversations/docs.bettercourses.org"
     issue-term="pathname"
     label="Comment"
     theme="github-light"

--- a/source/about/behind-the-scenes/technical-stack.rst
+++ b/source/about/behind-the-scenes/technical-stack.rst
@@ -27,7 +27,7 @@ https://github.com/Better-Conversations/betterconversations.foundation,
 served by Caddy on one of our servers.
 
 The documentation website is built using Sphinx, GitHub repository here
-https://github.com/Better-Conversations/betterconversations.foundation,
+https://github.com/Better-Conversations/docs.bettercourses.org,
 served by Caddy on one of our servers.
 
 The web site bettercourses.org makes everything work. It does all the scheduling, enrolment, delivery console, certificates, etc.

--- a/source/conf.py
+++ b/source/conf.py
@@ -158,7 +158,7 @@ html_theme_options = {
     # "navbar_end": ["navbar-icon-links"],
     # "navbar_persistent": ["search-button"],
     # "content_footer_items": ["last-updated"],
-    "github_url": "https://github.com/Better-Conversations/betterconversations.foundation",
+    "github_url": "https://github.com/Better-Conversations/docs.bettercourses.org",
     # "use_edit_page_button": True,
     "show_nav_level": 2,
     "header_links_before_dropdown": 5,
@@ -181,7 +181,7 @@ html_sidebars = {
     'blog/*': ['ablog/recentposts.html', 'ablog/tagcloud.html', 'ablog/categories.html', 'ablog/archives.html']
 }
 
-html_baseurl = "https://betterconversations.foundation/"
+html_baseurl = "https://docs.bettercourses.org/"
 
 # Don't share the source 
 html_copy_source = False
@@ -191,7 +191,7 @@ html_copy_source = False
 skip_injecting_base_ablog_templates = False
 
 blog_title = "News from the BCF"
-blog_baseurl = "https://betterconversations.foundation/blog"
+blog_baseurl = "https://docs.bettercourses.org/blog"
 post_date_format_short = "%b %d, %Y"
 post_auto_image = 1 # Don't automatically add images, set to 1 to return the first image in the post
 templates_path = ['_templates']

--- a/source/conf.py
+++ b/source/conf.py
@@ -163,8 +163,8 @@ html_theme_options = {
     "show_nav_level": 2,
     "header_links_before_dropdown": 5,
     "show_prev_next": True,
-    "secondary_sidebar_items": [],
-    "content_footer_items": ["last-updated"]   
+    "secondary_sidebar_items": []
+    # "content_footer_items": ["last-updated"]
     # "content_footer_items": ["last-updated", "utterances"]   
    # "logo": {
     #    "alt_text": "Better Conversations Foundation",

--- a/source/conf.py
+++ b/source/conf.py
@@ -163,7 +163,7 @@ html_theme_options = {
     "show_nav_level": 2,
     "header_links_before_dropdown": 5,
     "show_prev_next": True,
-    "secondary_sidebar_items": []
+    "secondary_sidebar_items": [],
     # "content_footer_items": ["last-updated"]
     # "content_footer_items": ["last-updated", "utterances"]   
    # "logo": {

--- a/source/index.rst
+++ b/source/index.rst
@@ -83,7 +83,3 @@ If you want to know more, or if you want to get involved, please get in touch wi
    documentation/index
    work-with-us/index
    blog/index
-
-
-.. qms_header::
-

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Disallow:
-Sitemap: https://betterconversations.foundation/sitemap.xml
+Sitemap: https://docs.bettercourses.org/sitemap.xml


### PR DESCRIPTION
- Auto-inject collapsible QMS header at bottom of every page
- Add Git Commit Date field with linked SHA and timestamp
- Remove manual qms_header directive from index.rst
- Remove footer last-updated (now in QMS header)

Closes BCTT-608