### PR TITLE
Fix git safe directory path for QMS header

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Configure Git safe directory
         shell: bash
         run: |
-          git config --global --add safe.directory /__w/betterconversations.foundation/betterconversations.foundation
+          git config --global --add safe.directory /__w/docs.bettercourses.org/docs.bettercourses.org
 
       - name: Install Sphinx
         shell: bash


### PR DESCRIPTION
The git safe directory was configured with the wrong repository name (betterconversations.foundation instead of docs.bettercourses.org), causing git commands to fail silently during CI builds. This resulted in QMS headers showing "unknown" for author, date, and commit fields.

Fixes BCTT-611