### PR TITLE
Fix pattern TODO references: correct issue IDs and remove completed items

### DIFF
--- a/source/documentation/patterns/core-delivery/index.rst
+++ b/source/documentation/patterns/core-delivery/index.rst
@@ -14,6 +14,5 @@ These patterns are the key patterns for how to deliver the course.
    
 .. todo::
 
-    - BCF-656: New version of course flight plans v3.1.2 (foundational structure)
     - BCOBS-1126: Document patterns for co-facilitation (proven coordination approach)
-    - BCF-6: Flight plan pattern - additional documentation (reliable framework) 
+    - BCOBS-1138: Flight plan pattern - additional documentation (reliable framework)

--- a/source/documentation/patterns/exercises/index.rst
+++ b/source/documentation/patterns/exercises/index.rst
@@ -14,6 +14,5 @@ These patterns are about how to run the breakout exercises in the course.
    
 .. todo::
     - BCOBS-1116: Document patterns for facilitators around breakout groups (works consistently)
-    - BCOBS-1119: Document patterns for producers on breakout groups (tested approach)
     - BCOBS-1118: Write up pattern of examples and demos before exercises (proven structure)
-    - BCF-669: When Fx goes into breakout (specific technique that works)
+    - BCOBS-1142: When Fx goes into breakout (specific technique that works)

--- a/source/documentation/patterns/visual-technical/index.rst
+++ b/source/documentation/patterns/visual-technical/index.rst
@@ -15,4 +15,3 @@ These patterns are about how to apply the visual and technical elements of the c
    
 .. todo::
     - BCOBS-1117: Document patterns for flipchart usage (consistent approach)
-    - BCOBS-749: Document what to do with odd numbers of people (tested solutions)


### PR DESCRIPTION
## Summary
- Remove completed TODO items (BCF-656, BCOBS-749, BCOBS-1119)
- Fix issue IDs that changed after team move (BCF-6 → BCOBS-1138, BCF-669 → BCOBS-1142)

## Context
Cherry-picked from the old `fix/update-pattern-todo-references` branch, which had diverged from `main` with duplicate history. This is a clean apply of just the TODO fix commit onto `main`.

## Test plan
- [x] Verify the TODO directives render correctly in the built docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)