### PR TITLE
Add breakout room pattern and fix template consistency

### DIFF
--- a/source/documentation/patterns/core-delivery/breakout-room-pattern.rst
+++ b/source/documentation/patterns/core-delivery/breakout-room-pattern.rst
@@ -1,0 +1,119 @@
+.. _breakout-room-pattern:
+
+=====================
+Breakout Room Pattern
+=====================
+
+.. tags:: patterns, breakout rooms, core delivery, timing
+
+.. warning::
+    This page is under development.
+
+When to use this pattern
+------------------------
+
+Breakout rooms are a key part of our core delivery. Through experimentation we have found that they help people engage with the content and with each other. We typically schedule them at ~20 and ~40 minute marks, because they introduce variation into the way people interact. They are also a chance for the delivery team to check in with each other, answer questions from observers and to get a sense of how the session is going.
+
+This pattern is written for online delivery using Zoom. If you are using a different platform or have in-person sessions, you will need to adapt it.
+
+The pattern
+-----------
+1. **Create rooms during the opening segment**
+
+   Create rooms and manually assign people as early as you can in the session and use participant state checkin information to help with pairing (don't pair people who are in red or yellow states if possible). Always pair (send in one of the facilitators if there are odd numbers) as it helps with the timing of the session.
+
+2. **Demo or give an example of what you want people to do**
+
+   Participants need to know what you want them to do. A demo or a quick example is helpful, and allows participants to ask questions about the exercise.
+
+3. **Brief clearly before sending**
+
+   Give specific instructions including the time allocation, remind participants about confidentiality and ask them if they have any questions. Keep strictly to the script in the flight plan as it has been tested and proven to work.
+
+4. **Send to breakouts**
+
+   Enabling automatic movement of participants to breakout rooms in Zoom and having a short cut-off (10s) before they return helps keep the session running on time. Pairing also helps with the timing of the session - we send a facilitator into a breakout room if there is an odd number of participants. The producer monitors the time and is best placed to know when to vary the length of the breakout room.
+
+5. **Return and unpack**
+
+   Bring people back promptly (and give the facilitator coming back a moment to get back into the right frame of mind before they continue facilitating). Facilitators ask participants to share insights on the exercise, sampling 2-3 responses. A flipchart might be used to capture key words and show the participants that you are listening to them.
+
+What makes this pattern reliable
+--------------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Key Element
+     - How it supports smooth delivery
+   * - Detailed timings
+     - These have been tested over 100s of sessions with consistent success. We know what types of question work and how long people need to discuss them. Moving them into the breakout room and not having a long countdown to come back really ups the pace of the session.
+   * - Role clarity
+     - The producer is best placed to know when to vary the length of the breakout room. They can watch how the session is going, how people are engaging and how long discussions are taking. Facilitators can help by checking with the producer before they brief the time e.g. "How long do we have for this exercise, Simon?"
+   * - Pairing
+     - We have tried this with groups of 2 and 3 and found pairing works best for timing and for people to engage with each other.
+   * - Standardised script
+     - Briefing the breakout exercise exactly as it is on the flight plan is one of the few things we know makes the session run smoothly. That's because the chat messages and instructions have been finely tuned over many sessions so that they are clear and concise.
+
+Variations we've tested
+-----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: auto
+
+   * - Variation
+     - How it works
+   * - Standard approach
+     - Flight plans detail the standard instructions for the breakout room, the messages copied into the Zoom chat, the time allocation and the questions for unpacking.
+   * - Making up pairs
+     - One facilitator joins the breakouts to make up a pair. This is also a good way to remind yourself of the participant experience. Remember to allow time for the facilitator to pick up their place on the flight plan and remember what they were doing before the breakout. Sometimes they forget and the second facilitator can adjust around that.
+   * - Breakouts of two and three participants
+     - Adding a third person to a breakout increases the time it takes to do the exercise well by about 30-50% (which is a lot when the session is 1 hour long). Extending the time of the breakout room is often necessary (and you need to find that time from elsewhere). Unpacking from each of the breakout pairs/threes instead of individually is a good way to gain time back.
+   * - For smaller groups
+     - Sometimes the group is small enough that you can ask everyone to share their insights. This is generally fine for 2-3 people, however timing is tight for 4 or more (so you need to sample).
+   * - For larger groups
+     - It becomes harder to thoughtfully pair people within larger groups. Also, sampling is essential when there are 4 or more people. This is where one facilitator watching the chat and the other facilitating verbal discussion is a good idea.
+   * - When timing is tight
+     - Reduce the time allocated for the breakout if possible. Unpack by asking people to write their answers in the chat and then pick out 1 or 2 examples to discuss.
+
+Evidence this pattern works
+---------------------------
+
+**Participant Experience**
+
+- Participants consistently say they enjoy the breakout rooms and it helps them get to know each other (even those who work in the same team).
+- New facilitators appreciate the break and a chance to plan how they will unpack the exercise.
+
+**Facilitator Development**
+
+- New facilitators appreciate the break and a chance to plan how they will unpack the exercise.
+
+**Operational Reliability**
+
+- The session runs smoothly and on time.
+- We vary the length of the breakout room to keep the session on track.
+
+Building on this pattern
+------------------------
+Knowing that we have natural breaks in each module has made it easier to design new modules (although the process of simplifying and clarifying what content works is a labour of love).
+
+It also makes it much easier to train people.
+
+.. todo::
+    - Add links to the relevant patterns and insights.
+    - See also: Flight Plan Pattern, Co-facilitation Pattern
+    - Link to related observations: BCOBS-1119, BCOBS-749, BCOBS-788, BCOBS-792, BCOBS-944, BCOBS-945, BCOBS-1000/1001, BCOBS-1091, BCOBS-754, BCOBS-759, BCOBS-765
+
+Reflections on our experience to date
+-------------------------------------
+We have found that the breakout room is a key part of the session. Basically, we prepare the participants for the exercise, send them off and then bring them back to share their insights. The :ref:`key to the success of the session <magic-in-conversations>` is what happens in their interactions on the course.
+
+Sometimes we have experimented with skipping the second breakout when the group discussion is really rich - often that doesn't work as well as if we had run the second breakout exercise. We are very careful now about varying from the two-breakout format.
+
+In early pilots, we had two, three and maybe even four breakout rooms. Participants seemed not to get as much out of the sessions with more than two breakouts. Two seems to be the sweet spot.
+
+In terms of content, the first breakout is useful to reflect on experience, the second is useful to explore the content in a future scenario, and to link to fieldwork. They provide balance to the session in this way.
+
+We also used to keep a record of who went in which breakout, which soon became unwieldy. We don't do that as routine now, except for when we are working with an :ref:`intact team <teams-vs-groups-insight>` where it is useful to track this, so we can ensure that team members can have conversations with each other over the whole of the course.

--- a/source/documentation/patterns/core-delivery/index.rst
+++ b/source/documentation/patterns/core-delivery/index.rst
@@ -11,7 +11,8 @@ These patterns are the key patterns for how to deliver the course.
    :titlesonly:
 
    flight-plan-pattern
-   
+   breakout-room-pattern
+
 .. todo::
 
     - BCOBS-1126: Document patterns for co-facilitation (proven coordination approach)

--- a/source/documentation/patterns/pattern-template.rst
+++ b/source/documentation/patterns/pattern-template.rst
@@ -26,8 +26,8 @@ The Pattern
 
    [What works - specific approach and why]
 
-What makes this reliable
-------------------------
+What makes this pattern reliable
+--------------------------------
 [Key elements that our experience shows are important]
 [Consider using a table to list the key elements and their importance]
 
@@ -43,8 +43,8 @@ Variations we've tested
 - **For smaller groups:** [Adjusted approach that maintains effectiveness]
 - **When time is tight:** [Shortened version that preserves key elements]
 
-Evidence this works
--------------------
+Evidence this pattern works
+---------------------------
 
 [Group by evidence type if relevant e.g. participant experience, facilitator development, operational reliability]
 


### PR DESCRIPTION
## Summary
- Add new `breakout-room-pattern.rst` documenting the proven breakout room approach (rescued from the unmerged `chandimad/BCOBS-1119-document-patterns-for-producers` branch)
- Fixed typos, added `.. warning::` banner, and aligned headings with the published flight-plan pattern
- Updated `pattern-template.rst` headings to match published patterns ("What makes this pattern reliable", "Evidence this pattern works")
- Added breakout-room-pattern to core-delivery toctree

## Context
The breakout room pattern content was written on the BCOBS-1119 branch (June 2025) but never merged due to branch divergence. The content is valuable and documents a core delivery practice. This PR rescues that content, fixes inconsistencies with the current template and published patterns, and corrects typos.

Relates to: BCOBS-1119

## Test plan
- [ ] Sphinx build completes without warnings from the new file
- [x] Breakout room pattern appears in core delivery patterns toctree
- [x] Cross-references (`:ref:`) in the document resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)